### PR TITLE
update io.github.alamahant.Asteria to v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Version 2.1.2 (2025-10-29) – Polish & Compatibility Update
+
+### Platform & Compatibility
+- **Updated KDE Runtime**: Upgraded to KDE Platform 6.9 for enhanced stability and performance
+- **Improved Qt 6.9 Compatibility**: Optimized QTableWidget rendering and font handling for the latest Qt framework
+
+### Astrological Accuracy
+- **Western Chart Convention**: Chart rendering now places the Ascendant at 9 o'clock position to align with standard Western astrological practices
+- **Zodiac Sign Coloring**: Planet list widget now displays zodiac signs in their traditional corresponding colors for better visual recognition
+
+### Code Quality & Performance
+- **Code Polish**: Various code improvements and optimizations throughout the application
+- **Enhanced Stability**: General bug fixes and performance enhancements for smoother user experience
+
+---
+
+
 ## Version 2.1.1 (2025-09-23) – Major Update
 
 ### Major Improvements & New Features

--- a/io.github.alamahant.Asteria.yml
+++ b/io.github.alamahant.Asteria.yml
@@ -1,6 +1,6 @@
 app-id: io.github.alamahant.Asteria
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: Asteria
 finish-args:
@@ -14,10 +14,11 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DFLATHUB_BUILD=ON
+      - -DCMAKE_BUILD_TYPE=Release
     sources:
       - type: git
         url: https://github.com/alamahant/Asteria.git
-        tag: v2.1.1
+        tag: v2.1.2
       - type: git
         url: https://github.com/aloistr/swisseph.git
         dest: swisseph_src


### PR DESCRIPTION
## Version 2.1.2 (2025-10-29) – Polish & Compatibility Update

### Platform & Compatibility
- **Updated KDE Runtime**: Upgraded to KDE Platform 6.9 for enhanced stability and performance
- **Improved Qt 6.9 Compatibility**: Optimized QTableWidget rendering and font handling for the latest Qt framework

### Astrological Accuracy
- **Western Chart Convention**: Chart rendering now places the Ascendant at 9 o'clock position to align with standard Western astrological practices
- **Zodiac Sign Coloring**: Planet list widget now displays zodiac signs in their traditional corresponding colors for better visual recognition

### Code Quality & Performance
- **Code Polish**: Various code improvements and optimizations throughout the application
- **Enhanced Stability**: General bug fixes and performance enhancements for smoother user experience

---
