### PR TITLE
update to v2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 2.1.6 (2026-05-16) – Major Cleanup & Size Reduction
+## Version 2.4.6 (2026-05-16) – Major Cleanup & Size Reduction
 
 ### Cleanup & Packaging
 - Major Flatpak cleanup reducing overall application size significantly
@@ -22,7 +22,7 @@
 
 ---
 
-## Version 2.1.5 (2026-03-02) – Multi-Provider AI Model Selector
+## Version 2.4.5 (2026-03-02) – Multi-Provider AI Model Selector
 
 ### Model Management
 - Added `ModelSelectorDialog` for managing multiple AI model configurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## Version 2.4.5 (2026-03-02) – Multi-Provider AI Model Selector
+## Version 2.1.6 (2026-05-16) – Major Cleanup & Size Reduction
+
+### Cleanup & Packaging
+- Major Flatpak cleanup reducing overall application size significantly
+- Removed unnecessary development files, headers, and build artifacts from runtime bundle
+- Cleaned up packaging structure for a more minimal and efficient deployment
+
+### Swiss Ephemeris
+- Confirmed static integration of Swiss Ephemeris engine
+- Runtime now only depends on `.se1` ephemeris data files
+- Removed unused ephemeris directories (`sat/`, `ep4/`) from final package
+
+### Build Improvements
+- Improved separation between build-time and runtime assets in CMake/Flatpak setup
+- More efficient and cleaner deployment process for Flathub builds
+
+### Stability
+- No functional changes to astrology calculations or AI features
+- Fully backward compatible with previous versions
+
+---
+
+## Version 2.1.5 (2026-03-02) – Multi-Provider AI Model Selector
 
 ### Model Management
 - Added `ModelSelectorDialog` for managing multiple AI model configurations

--- a/io.github.alamahant.Asteria.yml
+++ b/io.github.alamahant.Asteria.yml
@@ -19,9 +19,42 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/Asteria.git
-        tag: v2.1.5
-        commit: b728cedc06ed352a9989b79fc28a04eb0c48ca34
+        tag: v2.1.6
+        commit: 0f8df429aa4f244e359ca97baa0e06f687d00b2e
       - type: git
         url: https://github.com/aloistr/swisseph.git
         dest: swisseph_src
         commit: c353e6f813c825fcb7c4c005e4ebfdd2cf31c21b
+
+    cleanup:
+      - "/include"
+      - "/lib/pkgconfig"
+      - "/share/aclocal"
+      - "/share/man"
+      - "/share/doc"
+      - "/share/gtk-doc"
+
+      #- "*.a"
+      - "*.la"
+      - "*.h"
+
+      - "list.zip"
+      - "astlistn.md"
+      - "/share/swisseph/sat"
+      - "/share/swisseph/ep4"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/io.github.alamahant.Asteria.yml
+++ b/io.github.alamahant.Asteria.yml
@@ -19,8 +19,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/Asteria.git
-        tag: v2.1.6
-        commit: 0f8df429aa4f244e359ca97baa0e06f687d00b2e
+        tag: v2.4.6
+        commit: 4c17fcb4bd77015a558b39cf9dbc9a623c2d0003
       - type: git
         url: https://github.com/aloistr/swisseph.git
         dest: swisseph_src


### PR DESCRIPTION
## Version 2.1.6 (2026-05-16) – Major Cleanup & Size Reduction

### Cleanup & Packaging
- Major Flatpak cleanup reducing overall application size significantly
- Removed unnecessary development files, headers, and build artifacts from runtime bundle
- Cleaned up packaging structure for a more minimal and efficient deployment

### Swiss Ephemeris
- Confirmed static integration of Swiss Ephemeris engine
- Runtime now only depends on `.se1` ephemeris data files
- Removed unused ephemeris directories (`sat/`, `ep4/`) from final package

### Build Improvements
- Improved separation between build-time and runtime assets in CMake/Flatpak setup
- More efficient and cleaner deployment process for Flathub builds

### Stability
- No functional changes to astrology calculations or AI features
- Fully backward compatible with previous versions

---